### PR TITLE
Using single quoted string when no interpolation or special characters required.

### DIFF
--- a/bin/hrx
+++ b/bin/hrx
@@ -7,8 +7,8 @@ require 'thor'
 require 'hrx'
 
 class HRX::CLI < Thor
-  desc "create <archive> <paths>...", "Create a new archive"
-  option :root, aliases: :r, type: :string, banner: "Root of the archive"
+  desc 'create <archive> <paths>...', 'Create a new archive'
+  option :root, aliases: :r, type: :string, banner: 'Root of the archive'
   def create(destination, *paths)
     root = _normalize(Pathname.new(options[:root] || Dir.pwd))
 
@@ -46,7 +46,7 @@ class HRX::CLI < Thor
     relative = _normalize(Pathname.new(path)).relative_path_from(root).to_s
     relative.gsub!("\\", "/") if Gem.win_platform?
 
-    if relative.start_with?("../")
+    if relative.start_with?('../')
       raise Thor::Error.new("#{path} is not in #{options[:root] || 'the current directory'}")
     end
 

--- a/spec/executable/create_spec.rb
+++ b/spec/executable/create_spec.rb
@@ -12,26 +12,26 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-RSpec.describe "hrx create", type: :aruba do
+RSpec.describe 'hrx create', type: :aruba do
   before :each do
-    write_file("file1.txt", "contents 1\n")
-    write_file("file2.txt", "contents 2\n")
+    write_file('file1.txt', "contents 1\n")
+    write_file('file2.txt', "contents 2\n")
 
-    write_file("sub/file1.txt", "sub contents 1\n")
-    write_file("sub/file2.txt", "sub contents 2\n")
-    write_file("sub/.file.txt", "sub dot contents\n")
+    write_file('sub/file1.txt', "sub contents 1\n")
+    write_file('sub/file2.txt', "sub contents 2\n")
+    write_file('sub/.file.txt', "sub dot contents\n")
   end
 
-  it "creates an empty HRX file" do
-    run_simple "bin/hrx create archive.hrx"
+  it 'creates an empty HRX file' do
+    run_simple 'bin/hrx create archive.hrx'
 
-    expect("archive.hrx").to have_file_content("")
+    expect('archive.hrx').to have_file_content('')
   end
 
-  it "creates an HRX file with the given contents" do
-    run_simple "bin/hrx create archive.hrx file1.txt file2.txt"
+  it 'creates an HRX file with the given contents' do
+    run_simple 'bin/hrx create archive.hrx file1.txt file2.txt'
 
-    expect("archive.hrx").to have_file_content <<END
+    expect('archive.hrx').to have_file_content <<END
 <===> file1.txt
 contents 1
 
@@ -40,10 +40,10 @@ contents 2
 END
   end
 
-  it "creates an HRX file with everything in a directory" do
-    run_simple "bin/hrx create archive.hrx sub"
+  it 'creates an HRX file with everything in a directory' do
+    run_simple 'bin/hrx create archive.hrx sub'
 
-    expect("archive.hrx").to have_file_content <<END
+    expect('archive.hrx').to have_file_content <<END
 <===> sub/.file.txt
 sub dot contents
 
@@ -55,10 +55,10 @@ sub contents 2
 END
   end
 
-  it "writes filenames relative to --root" do
-    run "bin/hrx create --root sub archive.hrx sub"
+  it 'writes filenames relative to --root' do
+    run 'bin/hrx create --root sub archive.hrx sub'
 
-    expect("archive.hrx").to have_file_content <<END
+    expect('archive.hrx').to have_file_content <<END
 <===> .file.txt
 sub dot contents
 
@@ -70,43 +70,43 @@ sub contents 2
 END
   end
 
-  context "fails gracefully for" do
+  context 'fails gracefully for' do
     it "an input file that doesn't exist" do
-      run "bin/hrx create archive.hrx no-file.txt", fail_on_error: false
+      run 'bin/hrx create archive.hrx no-file.txt', fail_on_error: false
       expect(last_command_started).not_to be_successfully_executed
       expect(last_command_started.stderr).not_to include_a_stack_trace
     end
 
     it "an archive in a directory that doesn't exist" do
-      run "bin/hrx create no-dir/archive.hrx file1.txt", fail_on_error: false
+      run 'bin/hrx create no-dir/archive.hrx file1.txt', fail_on_error: false
       expect(last_command_started).not_to be_successfully_executed
       expect(last_command_started.stderr).not_to include_a_stack_trace
     end
 
     it "an input file that's not in the working directory" do
-      cd "sub"
+      cd 'sub'
 
-      run "bin/hrx create archive.hrx ../file1.txt", fail_on_error: false
+      run 'bin/hrx create archive.hrx ../file1.txt', fail_on_error: false
       expect(last_command_started).not_to be_successfully_executed
       expect(last_command_started.stderr).not_to include_a_stack_trace
     end
 
     it "an input file that's not in the root directory" do
-      run "bin/hrx create --root sub archive.hrx file1.txt", fail_on_error: false
+      run 'bin/hrx create --root sub archive.hrx file1.txt', fail_on_error: false
       expect(last_command_started).not_to be_successfully_executed
       expect(last_command_started.stderr).not_to include_a_stack_trace
     end
 
     it "an input file that's not valid UTF-8" do
-      write_file "invalid-file.txt", "\xc3\x28\n".b
-      run "bin/hrx create archive.hrx invalid-file.txt", fail_on_error: false
+      write_file 'invalid-file.txt', "\xc3\x28\n".b
+      run 'bin/hrx create archive.hrx invalid-file.txt', fail_on_error: false
       expect(last_command_started).not_to be_successfully_executed
       expect(last_command_started.stderr).not_to include_a_stack_trace
     end
 
-    it "an input file with an invalid path" do
-      touch "foo:bar.txt"
-      run "bin/hrx create archive.hrx foo:bar.txt", fail_on_error: false
+    it 'an input file with an invalid path' do
+      touch 'foo:bar.txt'
+      run 'bin/hrx create archive.hrx foo:bar.txt', fail_on_error: false
       expect(last_command_started).not_to be_successfully_executed
       expect(last_command_started.stderr).not_to include_a_stack_trace
     end


### PR DESCRIPTION
**Why?**
As per [Rubocop guidelines](https://github.com/rubocop-hq/ruby-style-guide#strings) using single quoted string if no interpolation is required or special character is present.

@nex3 I am not sure if ruby guidelines are followed for `hrx-ruby`, I strongly recommend to follow them. If this PR is approved and merged, and we agree on following these guidelines I will create more PR to fix these in rest of the files.